### PR TITLE
feat: wait till bentoml server is up on ec2 instance

### DIFF
--- a/bentoctl_aws_ec2/templates/terraform_default.tf
+++ b/bentoctl_aws_ec2/templates/terraform_default.tf
@@ -131,6 +131,24 @@ resource "aws_launch_template" "lt" {
 resource "aws_instance" "app_server" {
   launch_template {
     id = aws_launch_template.lt.id
+
+    provisioner "local-exec" {
+      command = <<-EOT
+        attempt_counter=0
+        max_attempts=15
+        printf 'waiting for server to start'
+        until $(curl --output /dev/null --silent --head --fail http://${self.public_ip}); do
+            if [ $attempt_counter -eq $max_attempts ];then
+              echo "Max attempts reached"
+              exit 1
+            fi
+
+            printf '.'
+            attempt_counter=$(($attempt_counter+1))
+            sleep 15
+        done
+        EOT
+    }
   }
 }
 

--- a/bentoctl_aws_ec2/templates/terraform_default.tf
+++ b/bentoctl_aws_ec2/templates/terraform_default.tf
@@ -136,7 +136,7 @@ resource "aws_instance" "app_server" {
   provisioner "local-exec" {
     command = <<-EOT
         attempt_counter=0
-        max_attempts=15
+        max_attempts=20
         printf 'waiting for server to start'
         until $(curl --output /dev/null --silent --head --fail http://${self.public_ip}); do
             if [ $attempt_counter -eq $max_attempts ];then

--- a/bentoctl_aws_ec2/templates/terraform_default.tf
+++ b/bentoctl_aws_ec2/templates/terraform_default.tf
@@ -131,9 +131,10 @@ resource "aws_launch_template" "lt" {
 resource "aws_instance" "app_server" {
   launch_template {
     id = aws_launch_template.lt.id
+  }
 
-    provisioner "local-exec" {
-      command = <<-EOT
+  provisioner "local-exec" {
+    command = <<-EOT
         attempt_counter=0
         max_attempts=15
         printf 'waiting for server to start'
@@ -148,7 +149,6 @@ resource "aws_instance" "app_server" {
             sleep 15
         done
         EOT
-    }
   }
 }
 


### PR DESCRIPTION
added a `local-exec` that will wait till the service is up and running before finishing the terraform apply step