### PR TITLE
fix: startup script should not use amazon-linux-extras

### DIFF
--- a/bentoctl_aws_ec2/templates/startup_script.sh
+++ b/bentoctl_aws_ec2/templates/startup_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo yum update -y
-sudo amazon-linux-extras install docker -y
+sudo yum install docker -y
 sudo service docker start
 sudo usermod -a -G docker ec2-user
 newgrp docker


### PR DESCRIPTION
Since the package 'amazon-linux-extras' is no longer available in Amazon Linux 2023, it needs to be replaced with 'yum' install in the startup script. 
The current script, which uses 'amazon-linux-extras', results in an infinite loop during the EC2 instance generation via terraform apply, ultimately leading to a failed deployment.

After changing the script from using 'amazon-linux-extras' to 'yum' install, I was able to successfully deploy my Bento model.